### PR TITLE
parsing unicode files Парсинг Юнікоду

### DIFF
--- a/yaml/Yaml.cpp
+++ b/yaml/Yaml.cpp
@@ -1457,12 +1457,13 @@ namespace Yaml
                 // Validate characters.
                 for (size_t i = 0; i < line.size(); i++)
                 {
-                    if (line[i] != '\t' && (line[i] < 32 || line[i] > 125))
+                    if (static_cast<unsigned char>(line[i]) != '\t' &&
+                       (static_cast<unsigned char>(line[i]) < 32 ||
+                        static_cast<unsigned char>(line[i]) == 127)) 
                     {
                         throw ParsingException(ExceptionMessage(g_ErrorInvalidCharacter, lineNo, i + 1));
                     }
                 }
-
                 // Validate tabs
                 const size_t firstTabPos    = line.find_first_of('\t');
                 size_t       startOffset    = line.find_first_not_of(" \t");


### PR DESCRIPTION
Fixed a bug that occurs when parsing yaml files not encoded in ASCII
Chart

Виправлено помилку яка виникає при парсингу файлів закодовани не ASCII
коді